### PR TITLE
atom-input-multiformとmodal-edit作成

### DIFF
--- a/template/admin/app/tags/atoms/atom-input.pug
+++ b/template/admin/app/tags/atoms/atom-input.pug
@@ -106,8 +106,8 @@ atom-input-multiform
     div.f.fm.mb8.cursor-pointer(each='{item, index in items}', onclick='{editItem}')
       div.mr4 {index}. 
       div.border.p8
-        p(each='{value in item}') 
-          span {opts.option.forms[index].label}: {value}
+        p(each='{form, i in opts.option.forms}') 
+          span {opts.option.forms[i].label}: {item[form.key]}
           br
     div(onclick='{createItem}')
       button.button.primary(type='button') 追加

--- a/template/admin/app/tags/atoms/atom-input.pug
+++ b/template/admin/app/tags/atoms/atom-input.pug
@@ -71,3 +71,71 @@ atom-input-image
         fr.readAsDataURL(file);
       })
     };
+
+atom-input-multiform
+  div.fs12.text-gray.mb8 {opts.option.label}
+  div
+    div.f.fm.mb8.cursor-pointer(each='{item, index in items}', onclick='{editItem}')
+      div.mr4 {index}. 
+      div.border.p8
+        p(each='{value, key in item}') 
+          span {key}: {value}
+          br
+    div(onclick='{createItem}')
+      button.button.primary(type='button') 追加
+
+  script.
+    var self = this;
+
+    this.on('mount', () => {
+      this.key = opts.option.key;
+      this.items = opts._value || [];
+      this.update();
+    });
+
+    this.createItem = (e) => {
+      // モーダルを開く
+      var modal = spat.modal.open('modal-edit', {
+        label: self.opts.option.label, // ラベル
+        forms: self.opts.option.forms, // 生成したいフォームを渡す（schemaと同じ）
+        readonly: self.opts.option.readonly,
+      });
+
+      modal.on('submit', (e) => {
+        var item = e.item;
+        this.items.push(item);
+
+        this.update();
+      });
+    };
+
+    this.editItem = (e) => {
+      var item = e.item.item;
+      var index = e.item.index;
+      var item_id = this.items[index].id;
+
+      // モーダルを作成
+      var modal = spat.modal.open('modal-edit', {
+        label: self.opts.option.label, // ラベル
+        forms: self.opts.option.forms, // 生成したいフォームを渡す（schemaと同じ）
+        item: item, // 編集したい場合は ここにメニューを渡す
+      });
+
+      // 更新
+      modal.on('submit', (event) => {
+        var item = event.item;
+        this.items[index] = item;
+
+        this.update();
+      });
+      
+      // 削除
+      modal.on('del', (event) => {
+        this.items.splice(index, 1);
+        this.update();
+      });
+    };
+
+    this.getValue = () => {
+      return this.items || null;
+    };

--- a/template/admin/app/tags/atoms/atom-input.pug
+++ b/template/admin/app/tags/atoms/atom-input.pug
@@ -78,8 +78,8 @@ atom-input-multiform
     div.f.fm.mb8.cursor-pointer(each='{item, index in items}', onclick='{editItem}')
       div.mr4 {index}. 
       div.border.p8
-        p(each='{value, key in item}') 
-          span {key}: {value}
+        p(each='{value in item}') 
+          span {opts.option.forms[index].label}: {value}
           br
     div(onclick='{createItem}')
       button.button.primary(type='button') 追加

--- a/template/admin/app/tags/modals/modal-edit.pug
+++ b/template/admin/app/tags/modals/modal-edit.pug
@@ -1,0 +1,61 @@
+modal-edit.f.fh.s-full
+  div.f.flex-column.flex-between.rounded-2.overflow-hidden.bg-white.modal(ref='modal')
+    div.s-full.overflow-scroll
+      div.bold.fs16.border-bottom.p16.bg-white {opts.label}
+      div.p16
+        div.mb16(each='{item in forms}', ref='{item.key}', data-is='atom-input-{item.type}', option='{item}', _value='{opts.item[item.key]}', data='{opts.item}')
+      
+      div.s-full.p12.f.fm
+        button.button.danger.w-full.py12.fs16.mr4(if='{!opts.readonly && mode==="edit"}', type='button', onclick='{_del}') 削除
+        button.button.primary.w-full.py12.fs16(onclick='{submit}') { mode==='edit' ? '編集' : '作成' }
+
+  style(type='less').
+    :scope {
+      background-color: rgba(0, 0, 0, 0.5);
+      .modal {
+        max-width: 600px;
+        min-width: 300px;
+      }
+    }
+
+  script.
+    var self = this;
+
+    this.on('mount', () => {
+      this.forms = opts.forms;
+      if (opts.item) this.mode = 'edit';
+      this.update();
+    });
+
+    this.submit = (e) => {
+      e.preventDefault();
+      var item = this.formToData();
+
+      this.trigger('submit', {item: item});
+
+      this.close();
+    };
+
+    this.formToData = (type) => {
+      var obj = {};
+      this.forms.forEach(item => {
+        var tag = self.refs[item.key];
+
+        if (!tag) return;
+
+        var key = (tag.getKey) ? tag.getKey() : item.key;
+
+        if (tag.getValue) {
+          obj[key] = tag.getValue();
+        }
+      });
+
+      return obj;
+    };
+
+    this._del = () => {
+      spat.modal.confirm('削除しますか？').on('confirm', () => {
+        this.trigger('del');
+        this.close();
+      });
+    };

--- a/template/admin/public/scripts/admin.js
+++ b/template/admin/public/scripts/admin.js
@@ -56,7 +56,16 @@
       ],
       edit: [
         { label: 'ID',    type: 'id', class: 'col1', class: 'w64' },
-        { label: 'タイトル',  type: 'text', key: 'data.title', class: 'col12' },
+        { label: 'タイトル', type: 'text', key: 'data.title', class: 'col12' },
+        {
+          key: 'data.options',
+          label: 'オプション',
+          type: 'multiform',
+          forms: [
+            { key: 'option1', label: 'オプション1', type: 'text' },
+            { key: 'option2', label: 'オプション2', type: 'text' },
+          ],
+        },
       ],
     },
   };


### PR DESCRIPTION
## データ構造
``` 
        {
          key: 'data.options',
          label: 'オプション',
          type: 'multiform',
          forms: [
            { key: 'option1', label: 'オプション1', type: 'text' },
            { key: 'option2', label: 'オプション2', type: 'text' },
          ],
        },

```

と設定した場合は

```

item.data.options = [
  { option1: 'text', option2: 'text' },
  { option1: 'text', option2: 'text' },
  ...
]

```

というふうに保存されます

## multiform

![image](https://user-images.githubusercontent.com/8247441/64099873-4c9a7680-cda5-11e9-87f3-642b10fccb8d.png)

## 要素をクリックしたとき(編集)

![image](https://user-images.githubusercontent.com/8247441/64075707-9a0bda80-ccf6-11e9-91fe-a7579a4ac3a8.png)

## 追加をクリック時

![image](https://user-images.githubusercontent.com/8247441/64075709-a001bb80-ccf6-11e9-8ecc-e8ea0469ee08.png)
